### PR TITLE
Create new managed identities to use in correct place

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -45,7 +45,7 @@ module "local_key_vault" {
   product_group_object_id    = "5d9cd025-a293-4b97-a0e5-6f43efce02c0"
   common_tags                = var.common_tags
   create_managed_identity    = true
-  managed_identity_object_ids = ["${data.azurerm_user_assigned_identity.em-shared-identity.principal_id}"]
+  managed_identity_object_ids = ["${data.azurerm_user_assigned_identity.em-shared-identity.principal_id}","${var.managed_identity_object_id}"]
 }
 
 data "azurerm_key_vault" "s2s_vault" {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -44,7 +44,8 @@ module "local_key_vault" {
   resource_group_name        = azurerm_resource_group.rg.name
   product_group_object_id    = "5d9cd025-a293-4b97-a0e5-6f43efce02c0"
   common_tags                = var.common_tags
-  managed_identity_object_ids = ["${data.azurerm_user_assigned_identity.em-shared-identity.principal_id}","${var.managed_identity_object_id}"]
+  create_managed_identity    = true
+  managed_identity_object_ids = ["${data.azurerm_user_assigned_identity.em-shared-identity.principal_id}"]
 }
 
 data "azurerm_key_vault" "s2s_vault" {


### PR DESCRIPTION
Creates new managed identities for use with workload identity



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
