### PR TITLE
local exclusion for config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ npm-debug.log.*
 dist/
 public/
 
+/config/local*.*
+
 # nyc test coverage
 .nyc_output
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "start": "NODE_ENV=production ./node_modules/.bin/ts-node -r tsconfig-paths/register server.ts",
+    "start:local": "NODE_ENV=local-dev ./node_modules/.bin/ts-node -r tsconfig-paths/register server.ts",
     "start:dev": "nodemon --inspect --config nodemon.json",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "NODE_ENV=test yarn test:unit",


### PR DESCRIPTION
add a gitignore and a new command to run icp. 
Previously there was no way to add to config without it being an unstaged commit and having the risk of secrets being added in commits by accident